### PR TITLE
Fixed helpURI. The old helpURI was incorrect and resulted in wrong helpURI -> 404

### DIFF
--- a/zimbra8/messages/ZmMsg_no.properties
+++ b/zimbra8/messages/ZmMsg_no.properties
@@ -1554,7 +1554,7 @@ help = Hjelp
 # NOTE: We do not translate this URL because it gets redirected by a
 #       servlet to the appropriate locale based on the user pref or
 #       browser locale.
-helpURI = /help/advanced/Zimbra_User_Help.htm
+helpURI = /help/advanced/zimbra_user_help.htm
 #L10N_IGNORE_BLOCK_END
 hiddenInGlobal = Privat - Listen er skjult i den globale adresselisten 
 hide = Skjul


### PR DESCRIPTION
Fixed helpURI. The old helpURI was incorrect and resulted in wrong helpURI and a 404 error page, when the end user tried to access the menu item Produkthjelp and got https://MYZIMBRASERVER/help/no/advanced/Zimbra_User_Help.htm which is incorrect

The fix will give you the correct URI:

https://MYZIMBRASERVER/help/en_US/advanced/zimbra_user_help.htm

Tested and verified on Zimbra 8.0.4 (Ubuntu 12.04 LTS)
